### PR TITLE
fix: handle body responses in webdav get

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-dav",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-dav",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-dav",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Custom n8n nodes for WebDAV, CalDAV, and CardDAV protocols",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
- ensure WebDAV get reads binary from `data` or `body` and errors when empty
- update WebDAV tests for body-based responses and strict binary handling
- bump package version

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7447ac9d883228553c6808f473383