### PR TITLE
Improve DAV nodes with dropdown selections and fixes

### DIFF
--- a/nodes/CalDav/CalDavDescription.ts
+++ b/nodes/CalDav/CalDavDescription.ts
@@ -101,21 +101,24 @@ const getCalendarsOperationFields: INodeProperties[] = [
 ];
 
 const getEventsOperationFields: INodeProperties[] = [
-	{
-		displayName: 'Calendar Path',
-		name: 'calendarPath',
-		type: 'string',
-		default: '',
-		placeholder: '/calendars/user/calendar/',
-		description: 'Path to the specific calendar. Start with "/". Spaces and special characters are auto-encoded.',
-		displayOptions: {
-			show: {
-				resource: ['calendar'],
-				operation: ['getEvents'],
-			},
-		},
-		required: true,
-	},
+        {
+                displayName: 'Calendar Name or ID',
+                name: 'calendarPath',
+                type: 'options',
+                noDataExpression: true,
+                typeOptions: { loadOptionsMethod: 'getCalendars' },
+                default: '',
+                placeholder: '/calendars/user/calendar/',
+                description:
+                        'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+                displayOptions: {
+                        show: {
+                                resource: ['calendar'],
+                                operation: ['getEvents'],
+                        },
+                },
+                required: true,
+        },
 	{
 		displayName: 'Time Range',
 		name: 'timeRange',
@@ -188,21 +191,24 @@ const getEventsOperationFields: INodeProperties[] = [
 ];
 
 const createEventOperationFields: INodeProperties[] = [
-	{
-		displayName: 'Calendar Path',
-		name: 'calendarPath',
-		type: 'string',
-		default: '',
-		placeholder: '/calendars/user/calendar/',
-		description: 'Path to the calendar where the event will be created. Start with "/". Spaces and special characters are auto-encoded.',
-		displayOptions: {
-			show: {
-				resource: ['calendar'],
-				operation: ['createEvent'],
-			},
-		},
-		required: true,
-	},
+        {
+                displayName: 'Calendar Name or ID',
+                name: 'calendarPath',
+                type: 'options',
+                noDataExpression: true,
+                typeOptions: { loadOptionsMethod: 'getCalendars' },
+                default: '',
+                placeholder: '/calendars/user/calendar/',
+                description:
+                        'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+                displayOptions: {
+                        show: {
+                                resource: ['calendar'],
+                                operation: ['createEvent'],
+                        },
+                },
+                required: true,
+        },
 	{
 		displayName: 'Event ID',
 		name: 'eventId',
@@ -235,21 +241,24 @@ const createEventOperationFields: INodeProperties[] = [
 ];
 
 const updateEventOperationFields: INodeProperties[] = [
-	{
-		displayName: 'Calendar Path',
-		name: 'calendarPath',
-		type: 'string',
-		default: '',
-		placeholder: '/calendars/user/calendar/',
-		description: 'Path to the calendar containing the event. Start with "/". Spaces and special characters are auto-encoded.',
-		displayOptions: {
-			show: {
-				resource: ['calendar'],
-				operation: ['updateEvent'],
-			},
-		},
-		required: true,
-	},
+        {
+                displayName: 'Calendar Name or ID',
+                name: 'calendarPath',
+                type: 'options',
+                noDataExpression: true,
+                typeOptions: { loadOptionsMethod: 'getCalendars' },
+                default: '',
+                placeholder: '/calendars/user/calendar/',
+                description:
+                        'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+                displayOptions: {
+                        show: {
+                                resource: ['calendar'],
+                                operation: ['updateEvent'],
+                        },
+                },
+                required: true,
+        },
 	{
 		displayName: 'Event ID',
 		name: 'eventId',
@@ -282,21 +291,24 @@ const updateEventOperationFields: INodeProperties[] = [
 ];
 
 const deleteEventOperationFields: INodeProperties[] = [
-	{
-		displayName: 'Calendar Path',
-		name: 'calendarPath',
-		type: 'string',
-		default: '',
-		placeholder: '/calendars/user/calendar/',
-		description: 'Path to the calendar containing the event. Start with "/". Spaces and special characters are auto-encoded.',
-		displayOptions: {
-			show: {
-				resource: ['calendar'],
-				operation: ['deleteEvent'],
-			},
-		},
-		required: true,
-	},
+        {
+                displayName: 'Calendar Name or ID',
+                name: 'calendarPath',
+                type: 'options',
+                noDataExpression: true,
+                typeOptions: { loadOptionsMethod: 'getCalendars' },
+                default: '',
+                placeholder: '/calendars/user/calendar/',
+                description:
+                        'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+                displayOptions: {
+                        show: {
+                                resource: ['calendar'],
+                                operation: ['deleteEvent'],
+                        },
+                },
+                required: true,
+        },
 	{
 		displayName: 'Event ID',
 		name: 'eventId',

--- a/nodes/WebDav/WebDav.node.ts
+++ b/nodes/WebDav/WebDav.node.ts
@@ -87,7 +87,12 @@ export class WebDav implements INodeType {
                                         body: xmlBody,
                                 } as any;
 
-                                const helpers: any = this.helpers;
+                                interface Helpers {
+                                        httpRequestWithAuthentication?: (this: ILoadOptionsFunctions, credName: string, options: object) => Promise<any>;
+                                        requestWithAuthentication?: (this: ILoadOptionsFunctions, credName: string, options: object) => Promise<any>;
+                                        httpRequest: (options: object) => Promise<any>;
+                                }
+                                const helpers = this.helpers as Helpers;
                                 let response: any;
                                 if (typeof helpers.httpRequestWithAuthentication === 'function') {
                                         response = await helpers.httpRequestWithAuthentication.call(this, 'davApi', options);

--- a/nodes/WebDav/WebDav.node.ts
+++ b/nodes/WebDav/WebDav.node.ts
@@ -59,18 +59,12 @@ export class WebDav implements INodeType {
 
         methods = {
                 loadOptions: {
-                        // Helper to retrieve and normalize the directory parameter
-                        getNormalizedDirectory(this: ILoadOptionsFunctions): string {
-                                let directory = (this.getCurrentNodeParameter('directory') as string) || '/';
-                                if (!directory.startsWith('/')) directory = `/${directory}`;
-                                return directory;
-                        },
-
                         async listDirectories(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
                                 const creds = (await this.getCredentials('davApi')) as { baseUrl: string };
                                 const baseUrl = creds.baseUrl.replace(/\/$/, '');
                                 const basePath = baseUrl.replace(/^https?:\/\/[^/]+/i, '');
-                                const directory = this.getNormalizedDirectory();
+                                let directory = (this.getCurrentNodeParameter('directory') as string) || '/';
+                                if (!directory.startsWith('/')) directory = `/${directory}`;
 
                                 const xmlBody = `<?xml version="1.0" encoding="utf-8"?>
 <D:propfind xmlns:D="DAV:">

--- a/nodes/WebDav/WebDav.node.ts
+++ b/nodes/WebDav/WebDav.node.ts
@@ -59,12 +59,18 @@ export class WebDav implements INodeType {
 
         methods = {
                 loadOptions: {
+                        // Helper to retrieve and normalize the directory parameter
+                        getNormalizedDirectory(this: ILoadOptionsFunctions): string {
+                                let directory = (this.getCurrentNodeParameter('directory') as string) || '/';
+                                if (!directory.startsWith('/')) directory = `/${directory}`;
+                                return directory;
+                        },
+
                         async listDirectories(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
                                 const creds = (await this.getCredentials('davApi')) as { baseUrl: string };
                                 const baseUrl = creds.baseUrl.replace(/\/$/, '');
                                 const basePath = baseUrl.replace(/^https?:\/\/[^/]+/i, '');
-                                let directory = (this.getCurrentNodeParameter('directory') as string) || '/';
-                                if (!directory.startsWith('/')) directory = `/${directory}`;
+                                const directory = this.getNormalizedDirectory();
 
                                 const xmlBody = `<?xml version="1.0" encoding="utf-8"?>
 <D:propfind xmlns:D="DAV:">

--- a/nodes/WebDav/WebDav.node.ts
+++ b/nodes/WebDav/WebDav.node.ts
@@ -87,12 +87,7 @@ export class WebDav implements INodeType {
                                         body: xmlBody,
                                 } as any;
 
-                                interface Helpers {
-                                        httpRequestWithAuthentication?: (this: ILoadOptionsFunctions, credName: string, options: object) => Promise<any>;
-                                        requestWithAuthentication?: (this: ILoadOptionsFunctions, credName: string, options: object) => Promise<any>;
-                                        httpRequest: (options: object) => Promise<any>;
-                                }
-                                const helpers = this.helpers as Helpers;
+                                const helpers: any = this.helpers;
                                 let response: any;
                                 if (typeof helpers.httpRequestWithAuthentication === 'function') {
                                         response = await helpers.httpRequestWithAuthentication.call(this, 'davApi', options);

--- a/nodes/WebDav/WebDavDescription.ts
+++ b/nodes/WebDav/WebDavDescription.ts
@@ -113,21 +113,40 @@ export const webDavOperations: INodeProperties[] = [
 
 // WebDAV Fields
 const getOperationFields: INodeProperties[] = [
-	{
-		displayName: 'Path',
-		name: 'path',
-		type: 'string',
-		default: '',
-		placeholder: '/path/to/file.txt',
-		description: 'Path to the file on the WebDAV server. Start with "/". Spaces and special characters are auto-encoded. Supports expressions like {{$JSON.filename}}.',
-		displayOptions: {
-			show: {
-				resource: ['file'],
-				operation: ['get'],
-			},
-		},
-		required: true,
-	},
+        {
+                displayName: 'Directory Name or ID',
+                name: 'directory',
+                type: 'options',
+                noDataExpression: true,
+                typeOptions: { loadOptionsMethod: 'listDirectories' },
+                default: '',
+                description:
+                        'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+                displayOptions: {
+                        show: {
+                                resource: ['file'],
+                                operation: ['get'],
+                        },
+                },
+        },
+        {
+                displayName: 'File Name or ID',
+                name: 'path',
+                type: 'options',
+                noDataExpression: true,
+                typeOptions: { loadOptionsMethod: 'listFiles', loadOptionsDependsOn: ['directory'] },
+                default: '',
+                placeholder: '/path/to/file.txt',
+                description:
+                        'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+                displayOptions: {
+                        show: {
+                                resource: ['file'],
+                                operation: ['get'],
+                        },
+                },
+                required: true,
+        },
 ];
 
 const putOperationFields: INodeProperties[] = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-dav",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-dav",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-dav",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Custom n8n nodes for WebDAV, CalDAV, and CardDAV protocols",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
- fix CalDAV/WebDAV responses to use body and statusCode
- add calendar dropdowns and WebDAV directory/file browsing
- bump version via `npm version patch`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b74f451c588322b5ef19bf4df07c83