### PR TITLE
Enhance CardDav Node to work with iCloud CardDAV

### DIFF
--- a/credentials/DavApi.credentials.ts
+++ b/credentials/DavApi.credentials.ts
@@ -56,7 +56,13 @@ export class DavApi implements ICredentialType {
 			method: 'PROPFIND' as any,
 			headers: {
 				Depth: '0',
+				'Content-Type': 'application/xml',
 			},
+			body:
+				'<?xml version="1.0" encoding="utf-8"?>' +
+				'<d:propfind xmlns:d="DAV:">' +
+				'<d:prop><d:current-user-principal/></d:prop>' +
+				'</d:propfind>',
 		},
 	};
 }


### PR DESCRIPTION
- **DavApi.credentials.ts**:
  - Added `Content-Type: application/xml` header to the PROPFIND request.
  - Included XML body for the PROPFIND request to retrieve the current user principal.

- **CardDav.node.ts**:
  - Updated regex patterns to be namespace-agnostic, improving XML parsing for `response`, `href`, `displayname`, `addressbook-description`, `getetag`, and `address-data` elements.
  - Modified the handling of response data to accommodate both `response.data` and `response.body`.
  - Added `Depth: '1'` header to the REPORT request for `getContacts` to ensure compatibility with iCloud's addressbook-query requirements.
  - Ensured consistent extraction of `statusCode` from the response, defaulting to `response.status` if `response.statusCode` is unavailable.

These changes improve the robustness and compatibility of the CardDav node and DavApi credentials, particularly in handling XML responses and interacting with iCloud services.
